### PR TITLE
Build Debian based Prince 13.1 images

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,37 @@
+ARG BASE_IMAGE
+
+FROM debian:${BASE_IMAGE}
+
+ARG PRINCE_VERSION
+ARG DEBIAN_VERSION
+ARG DEB_FILE=prince_${PRINCE_VERSION}-1_debian${DEBIAN_VERSION}_amd64.deb
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+      curl \
+      ca-certificates \
+      fonts-tlwg-garuda-otf \
+      fonts-lohit-orya \
+      fonts-lohit-mlym \
+      fonts-lohit-knda \
+      fonts-lohit-telu \
+      fonts-lohit-taml \
+      fonts-lohit-gujr \
+      fonts-lohit-guru \
+      fonts-lohit-beng-bengali \
+      fonts-lohit-deva \
+      fonts-baekmuk \
+      fonts-ipafont-mincho \
+      fonts-arphic-uming \
+      fonts-opensymbol \
+      fonts-liberation2 && \
+    curl --proto '=https' --tlsv1.2 -O https://www.princexml.com/download/${DEB_FILE} && \
+    apt-get install -y ./${DEB_FILE} && \
+    rm ${DEB_FILE} && \
+    apt-get purge -y curl ca-certificates && \
+    apt-get autoremove -y && apt-get clean
+
+ENTRYPOINT ["prince"]
+
+CMD ["--help"]
+
+# vi: ft=dockerfile

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -27,8 +27,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     curl --proto '=https' --tlsv1.2 -O https://www.princexml.com/download/${DEB_FILE} && \
     apt-get install -y ./${DEB_FILE} && \
     rm ${DEB_FILE} && \
-    apt-get purge -y curl ca-certificates && \
-    apt-get autoremove -y && apt-get clean
+    apt-get purge -y curl && \
+    apt-get autoremove -y && apt-get clean && \
+    ln -sf /etc/ssl/certs/ca-certificates.crt /usr/lib/prince/etc/curl-ca-bundle.crt
 
 ENTRYPOINT ["prince"]
 

--- a/Dockerfile.debian-slim
+++ b/Dockerfile.debian-slim
@@ -1,0 +1,37 @@
+ARG DEBIAN_VERSION
+
+FROM debian:${DEBIAN_VERSION}-slim
+
+ARG PRINCE_VERSION
+ARG DEBIAN_VERSION
+ARG DEB_FILE=prince_${PRINCE_VERSION}-1_debian${DEBIAN_VERSION}_amd64.deb
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+      curl \
+      ca-certificates \
+      fonts-tlwg-garuda-otf \
+      fonts-lohit-orya \
+      fonts-lohit-mlym \
+      fonts-lohit-knda \
+      fonts-lohit-telu \
+      fonts-lohit-taml \
+      fonts-lohit-gujr \
+      fonts-lohit-guru \
+      fonts-lohit-beng-bengali \
+      fonts-lohit-deva \
+      fonts-baekmuk \
+      fonts-ipafont-mincho \
+      fonts-arphic-uming \
+      fonts-opensymbol \
+      fonts-liberation2 && \
+    curl --proto '=https' --tlsv1.2 -O https://www.princexml.com/download/${DEB_FILE} && \
+    apt-get install -y ./${DEB_FILE} && \
+    rm ${DEB_FILE} && \
+    apt-get purge -y curl ca-certificates && \
+    apt-get autoremove -y && apt-get clean
+
+ENTRYPOINT ["prince"]
+
+CMD ["--help"]
+
+# vi: ft=dockerfile

--- a/Dockerfile.debian8
+++ b/Dockerfile.debian8
@@ -1,6 +1,6 @@
-ARG DEBIAN_VERSION
+ARG BASE_IMAGE
 
-FROM debian:${DEBIAN_VERSION}-slim
+FROM debian:${BASE_IMAGE}
 
 ARG PRINCE_VERSION
 ARG DEBIAN_VERSION
@@ -9,7 +9,8 @@ ARG DEB_FILE=prince_${PRINCE_VERSION}-1_debian${DEBIAN_VERSION}_amd64.deb
 RUN apt-get update && apt-get install --no-install-recommends -y \
       curl \
       ca-certificates \
-      fonts-tlwg-garuda-otf \
+      gdebi-core \
+      fonts-tlwg-garuda \
       fonts-lohit-orya \
       fonts-lohit-mlym \
       fonts-lohit-knda \
@@ -23,11 +24,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
       fonts-ipafont-mincho \
       fonts-arphic-uming \
       fonts-opensymbol \
-      fonts-liberation2 && \
+      fonts-liberation && \
     curl --proto '=https' --tlsv1.2 -O https://www.princexml.com/download/${DEB_FILE} && \
-    apt-get install -y ./${DEB_FILE} && \
+    gdebi ./${DEB_FILE} && \
     rm ${DEB_FILE} && \
-    apt-get purge -y curl ca-certificates && \
+    apt-get purge -y curl ca-certificates gdebi-core && \
     apt-get autoremove -y && apt-get clean
 
 ENTRYPOINT ["prince"]

--- a/Dockerfile.debian8
+++ b/Dockerfile.debian8
@@ -26,10 +26,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
       fonts-opensymbol \
       fonts-liberation && \
     curl --proto '=https' --tlsv1.2 -O https://www.princexml.com/download/${DEB_FILE} && \
-    gdebi ./${DEB_FILE} && \
+    gdebi -n ./${DEB_FILE} && \
     rm ${DEB_FILE} && \
-    apt-get purge -y curl ca-certificates gdebi-core && \
-    apt-get autoremove -y && apt-get clean
+    apt-get purge -y curl gdebi-core && \
+    apt-get autoremove -y && apt-get clean && \
+    ln -sf /etc/ssl/certs/ca-certificates.crt /usr/lib/prince/etc/curl-ca-bundle.crt
 
 ENTRYPOINT ["prince"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+PRINCE_VERSION?=13.1
+
+all:
+
+debian-slim: debian-8-slim debian-9-slim debian-10-slim
+
+debian-10-slim: Dockerfile.debian-slim
+	docker build \
+	  -f $< \
+	  -t yeslogic/prince:$(PRINCE_VERSION) \
+	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
+	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
+	  --build-arg DEBIAN_VERSION=10 \
+	  .

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,63 @@
 PRINCE_VERSION?=13.1
 
-all:
+all: debian debian-slim
+
+debian: debian-8 debian-9 debian-10
 
 debian-slim: debian-8-slim debian-9-slim debian-10-slim
 
-debian-10-slim: Dockerfile.debian-slim
+debian-10: Dockerfile.debian
+	docker build \
+	  -f $< \
+	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
+	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
+	  --build-arg DEBIAN_VERSION=10 \
+	  --build-arg BASE_IMAGE=10 \
+	  .
+
+debian-9: Dockerfile.debian
+	docker build \
+	  -f $< \
+	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
+	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
+	  --build-arg DEBIAN_VERSION=9 \
+	  --build-arg BASE_IMAGE=9 \
+	  .
+
+debian-8: Dockerfile.debian8
+	docker build \
+	  -f $< \
+	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
+	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
+	  --build-arg DEBIAN_VERSION=8 \
+	  --build-arg BASE_IMAGE=8 \
+	  .
+
+debian-10-slim: Dockerfile.debian
 	docker build \
 	  -f $< \
 	  -t yeslogic/prince:$(PRINCE_VERSION) \
 	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
 	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
 	  --build-arg DEBIAN_VERSION=10 \
+	  --build-arg BASE_IMAGE=10-slim \
 	  .
+
+debian-9-slim: Dockerfile.debian
+	docker build \
+	  -f $< \
+	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
+	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
+	  --build-arg DEBIAN_VERSION=9 \
+	  --build-arg BASE_IMAGE=9-slim \
+	  .
+
+debian-8-slim: Dockerfile.debian8
+	docker build \
+	  -f $< \
+	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
+	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
+	  --build-arg DEBIAN_VERSION=8 \
+	  --build-arg BASE_IMAGE=8-slim \
+	  .
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+DOCKER?=docker
 PRINCE_VERSION?=13.1
 
 all: debian debian-slim
@@ -7,7 +8,7 @@ debian: debian-8 debian-9 debian-10
 debian-slim: debian-8-slim debian-9-slim debian-10-slim
 
 debian-10: Dockerfile.debian
-	docker build \
+	$(DOCKER) build \
 	  -f $< \
 	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
 	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
@@ -16,7 +17,7 @@ debian-10: Dockerfile.debian
 	  .
 
 debian-9: Dockerfile.debian
-	docker build \
+	$(DOCKER) build \
 	  -f $< \
 	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
 	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
@@ -25,7 +26,7 @@ debian-9: Dockerfile.debian
 	  .
 
 debian-8: Dockerfile.debian8
-	docker build \
+	$(DOCKER) build \
 	  -f $< \
 	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
 	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
@@ -34,7 +35,7 @@ debian-8: Dockerfile.debian8
 	  .
 
 debian-10-slim: Dockerfile.debian
-	docker build \
+	$(DOCKER) build \
 	  -f $< \
 	  -t yeslogic/prince:$(PRINCE_VERSION) \
 	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
@@ -44,7 +45,7 @@ debian-10-slim: Dockerfile.debian
 	  .
 
 debian-9-slim: Dockerfile.debian
-	docker build \
+	$(DOCKER) build \
 	  -f $< \
 	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
 	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
@@ -53,7 +54,7 @@ debian-9-slim: Dockerfile.debian
 	  .
 
 debian-8-slim: Dockerfile.debian8
-	docker build \
+	$(DOCKER) build \
 	  -f $< \
 	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
 	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
@@ -61,3 +62,11 @@ debian-8-slim: Dockerfile.debian8
 	  --build-arg BASE_IMAGE=8-slim \
 	  .
 
+dockerhub: all
+	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)
+	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)-debian-10
+	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)-debian-9
+	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)-debian-8
+	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)-debian-10-slim
+	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)-debian-9-slim
+	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)-debian-8-slim

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ indicate the same image):
 * `yeslogic/prince:13.1-debian-9`
 * `yeslogic/prince:13.1-debian-8`
 
+Example:
+
+```shell
+docker run --rm -it -v $(pwd):/out yeslogic/prince:13.1 https://example.com/ -o /out/example.pdf
+```
+
 ## Building
 
 Build all:

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Dockerfiles for building Docker images with [Prince] installed.
 Images are available with the following tags (multiple tags on the same line
 indicate the same image):
 
-* `yeslogic/prince-13.1` `yeslogic/prince-13.1-debian-10-slim`
-* `yeslogic/prince-13.1-debian-9-slim`
-* `yeslogic/prince-13.1-debian-8-slim`
-* `yeslogic/prince-13.1-debian-10`
-* `yeslogic/prince-13.1-debian-9`
-* `yeslogic/prince-13.1-debian-8`
+* `yeslogic/prince:13.1` `yeslogic/prince:13.1-debian-10-slim`
+* `yeslogic/prince:13.1-debian-9-slim`
+* `yeslogic/prince:13.1-debian-8-slim`
+* `yeslogic/prince:13.1-debian-10`
+* `yeslogic/prince:13.1-debian-9`
+* `yeslogic/prince:13.1-debian-8`
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # docker-prince
-Prince Dockerfiles
+
+Dockerfiles for building Docker images with [Prince] installed.
+
+## Using
+
+Images are available with the following tags (multiple tags on the same line
+indicate the same image):
+
+* `yeslogic/prince-13.1` `yeslogic/prince-13.1-debian-10-slim`
+* `yeslogic/prince-13.1-debian-9-slim`
+* `yeslogic/prince-13.1-debian-8-slim`
+* `yeslogic/prince-13.1-debian-10`
+* `yeslogic/prince-13.1-debian-9`
+* `yeslogic/prince-13.1-debian-8`
+
+## Building
+
+Build all:
+
+    make
+
+Build a specific image:
+
+    make debian-10
+
+Available targets:
+
+* `debian-8`
+* `debian-9`
+* `debian-10`
+* `debian-8-slim`
+* `debian-9-slim`
+* `debian-10-slim`
+
+[Prince]: https://www.princexml.com/


### PR DESCRIPTION
Dockerfiles and Makefile for building Prince Docker images based on `debian-{8,9,10}` and `debian-{8,9,10}-slim` images. Other images can be added as needed.

The Makefile is a bit repetitious. I'm open to improvements/recommendations on how to make it nicer.