### PR TITLE
Add noto, khmeros, and lklug fonts

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -9,6 +9,9 @@ ARG DEB_FILE=prince_${PRINCE_VERSION}-1_debian${DEBIAN_VERSION}_amd64.deb
 RUN apt-get update && apt-get install --no-install-recommends -y \
       curl \
       ca-certificates \
+      fonts-noto \
+      fonts-khmeros-core \
+      fonts-lklug-sinhala \
       fonts-tlwg-garuda-otf \
       fonts-lohit-orya \
       fonts-lohit-mlym \


### PR DESCRIPTION
Unsure if `Dockerfile.debian8` should also be updated. I can't find any references to it in the repo, so I assume it's being kept around for historical purposes.