### PR TITLE
Build multi-platform images for amd64 and arm64

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,10 +1,12 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=12
 
 FROM debian:${BASE_IMAGE}
 
 ARG PRINCE_VERSION
 ARG DEBIAN_VERSION
-ARG DEB_FILE=prince_${PRINCE_VERSION}-1_debian${DEBIAN_VERSION}_amd64.deb
+# This argument is populated automatically by Docker
+ARG TARGETARCH
+ARG DEB_FILE=prince_${PRINCE_VERSION}-1_debian${DEBIAN_VERSION}_${TARGETARCH}.deb
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
       curl \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DOCKER?=docker
 DOCKER_DEFAULT_PLATFORM?=linux/amd64
+BUILD_PLATFORMS?=linux/amd64,linux/arm64
 PRINCE_VERSION?=16
 
 export DOCKER_DEFAULT_PLATFORM
@@ -11,8 +12,9 @@ debian: debian-11 debian-12
 debian-slim: debian-11-slim debian-12-slim
 
 debian-12: Dockerfile.debian
-	$(DOCKER) build \
+	$(DOCKER) buildx build \
 	  -f $< \
+	  --platform $(BUILD_PLATFORMS) \
 	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
 	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
 	  --build-arg DEBIAN_VERSION=12 \
@@ -20,8 +22,9 @@ debian-12: Dockerfile.debian
 	  .
 
 debian-11: Dockerfile.debian
-	$(DOCKER) build \
+	$(DOCKER) buildx build \
 	  -f $< \
+	  --platform $(BUILD_PLATFORMS) \
 	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
 	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
 	  --build-arg DEBIAN_VERSION=11 \
@@ -29,8 +32,9 @@ debian-11: Dockerfile.debian
 	  .
 
 debian-12-slim: Dockerfile.debian
-	$(DOCKER) build \
+	$(DOCKER) buildx build \
 	  -f $< \
+	  --platform $(BUILD_PLATFORMS) \
 	  -t yeslogic/prince:latest \
 	  -t yeslogic/prince:$(PRINCE_VERSION) \
 	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
@@ -40,8 +44,9 @@ debian-12-slim: Dockerfile.debian
 	  .
 
 debian-11-slim: Dockerfile.debian
-	$(DOCKER) build \
+	$(DOCKER) buildx build \
 	  -f $< \
+	  --platform $(BUILD_PLATFORMS) \
 	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
 	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
 	  --build-arg DEBIAN_VERSION=11 \

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ export DOCKER_DEFAULT_PLATFORM
 
 all: debian debian-slim
 
-debian: debian-10 debian-11 debian-12
+debian: debian-11 debian-12
 
-debian-slim: debian-10-slim debian-11-slim debian-12-slim
+debian-slim: debian-11-slim debian-12-slim
 
 debian-12: Dockerfile.debian
 	$(DOCKER) build \
@@ -26,15 +26,6 @@ debian-11: Dockerfile.debian
 	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
 	  --build-arg DEBIAN_VERSION=11 \
 	  --build-arg BASE_IMAGE=11 \
-	  .
-
-debian-10: Dockerfile.debian
-	$(DOCKER) build \
-	  -f $< \
-	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
-	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
-	  --build-arg DEBIAN_VERSION=10 \
-	  --build-arg BASE_IMAGE=10 \
 	  .
 
 debian-12-slim: Dockerfile.debian
@@ -57,21 +48,10 @@ debian-11-slim: Dockerfile.debian
 	  --build-arg BASE_IMAGE=11-slim \
 	  .
 
-debian-10-slim: Dockerfile.debian
-	$(DOCKER) build \
-	  -f $< \
-	  -t yeslogic/prince:$(PRINCE_VERSION)-$@ \
-	  --build-arg PRINCE_VERSION=$(PRINCE_VERSION) \
-	  --build-arg DEBIAN_VERSION=10 \
-	  --build-arg BASE_IMAGE=10-slim \
-	  .
-
 dockerhub: all
 	$(DOCKER) push yeslogic/prince:latest
 	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)
 	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)-debian-12
 	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)-debian-11
-	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)-debian-10
 	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)-debian-12-slim
 	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)-debian-11-slim
-	$(DOCKER) push yeslogic/prince:$(PRINCE_VERSION)-debian-10-slim

--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@ indicate the same image):
 
 * `yeslogic/prince:latest` `yeslogic/prince:16` `yeslogic/prince:16-debian-12-slim`
 * `yeslogic/prince:16-debian-11-slim`
-* `yeslogic/prince:16-debian-10-slim`
 * `yeslogic/prince:16-debian-12`
 * `yeslogic/prince:16-debian-11`
-* `yeslogic/prince:16-debian-10`
 
 Example:
 
@@ -32,10 +30,8 @@ Build a specific image:
 
 Available targets:
 
-* `debian-10`
 * `debian-11`
 * `debian-12`
-* `debian-10-slim`
 * `debian-11-slim`
 * `debian-12-slim`
 

--- a/README.md
+++ b/README.md
@@ -20,15 +20,26 @@ docker run --rm -it -v $(pwd):/out yeslogic/prince:16 https://example.com/ -o /o
 
 ## Building
 
-Build all:
+By default the Makefile will build a [multi-platform] image for amd64 and arm64. On
+systems using Docker Desktop, this should work automatically. On Linux hosts you
+need to have `binfmt_misc` set up to run foreign binaries with QEMU. On Arch Linux
+I did this by installing the `qemu-user-static` and `qemu-user-static-binfmt` packages.
+
+[multi-platform]: https://docs.docker.com/build/building/multi-platform/
+
+### Build all
 
     make
 
-Build a specific image:
+### Build a specific image
 
     make debian-12
 
-Available targets:
+### Build for a single platform
+
+    make debian-12-slim BUILD_PLATFORMS=linux/amd64
+
+### Available targets
 
 * `debian-11`
 * `debian-12`


### PR DESCRIPTION
Also:

- Added a default value to `BASE_IMAGE` to suppress a warning from Docker
- Added `TARGETARCH` build argument, which is automatically populated by Docker
- Dropped Debian 10 as it's EoL and fails to build:
```
0.975 Err:4 http://deb.debian.org/debian buster Release
0.975   404  Not Found [IP: 151.101.98.132 80]
```